### PR TITLE
Allow consumer app to process notification payload instead of directly showing the notification

### DIFF
--- a/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
+++ b/kmpnotifier/src/androidMain/kotlin/com/mmk/kmpnotifier/firebase/MyFirebaseMessagingService.kt
@@ -8,7 +8,6 @@ import com.mmk.kmpnotifier.notification.NotifierManagerImpl
 internal class MyFirebaseMessagingService : FirebaseMessagingService() {
 
     private val notifierFactory by lazy { NotifierManagerImpl }
-    private val notifier: Notifier by lazy { notifierFactory.getLocalNotifier() }
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         println("FirebaseMessaging: onNewToken is called")
@@ -18,7 +17,7 @@ internal class MyFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         message.notification?.let {
-            notifier.notify(it.title ?: "", it.body ?: "")
+            notifierFactory.onPushNotificationPayload(it.title ?: "", it.body ?: "")
         }
         if (message.data.isNotEmpty()){
             notifierFactory.onPushPayloadData(message.data)

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManager.kt
@@ -49,6 +49,8 @@ public object NotifierManager {
          * @param data Push Notification Payload Data
          */
         public fun onPayloadData(data:PayloadData) {}
+
+        public fun onNotificationPayload(title: String, body: String) {}
     }
 
 

--- a/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
+++ b/kmpnotifier/src/commonMain/kotlin/com/mmk/kmpnotifier/notification/NotifierManagerImpl.kt
@@ -37,6 +37,12 @@ internal object NotifierManagerImpl : KMPKoinComponent() {
         listeners.forEach { it.onPayloadData(data) }
     }
 
+    fun onPushNotificationPayload(title: String, body: String) {
+        println("Received Push Notification payload")
+        if (listeners.size == 0) println("There is no listener to notify onPushNotificationPayload")
+        listeners.forEach { it.onNotificationPayload(title, body) }
+    }
+
     private fun requireInitialization() {
         if (LibDependencyInitializer.isInitialized().not()) throw IllegalStateException(
             "NotifierFactory is not initialized. " +


### PR DESCRIPTION
Tried this sample change to avoid showing notification when app is in foreground. Basically, when the app is in foreground, FCM delivers the notification payload to onMessageReceived. Instead of showing the notification, consumer app can decide what can be done using notification payload.